### PR TITLE
Remove access_locked?

### DIFF
--- a/lib/devise_date_restrictable/active_record.rb
+++ b/lib/devise_date_restrictable/active_record.rb
@@ -37,13 +37,6 @@ module Devise
 
       end
 
-      # Hook into lockable: verifies whether the user is locked for any reason.
-      def access_locked?
-
-        super && date_restricted?
-
-      end
-
       # Hook into authenticatable: verifies whether the user is available for authentication.
       def active_for_authentication?
 


### PR DESCRIPTION
There is a clash with Lockable which means that this gem overrides the access_locked?. So when your account gets locked by Lockable, it is still possible to log in if you guess the password correctly.
We have fixed this by removing access_locked? which still allows for date lockout as the user is not active for authentication.